### PR TITLE
Upgrade all dependencies to latest

### DIFF
--- a/distra.js
+++ b/distra.js
@@ -1,4 +1,5 @@
 var connect = require('connect')
+  , morgan = require('morgan')
   , http = require('http')
   , gzippo = require('gzippo')
   , http_proxy = require('http-proxy')
@@ -7,7 +8,7 @@ var connect = require('connect')
   , static_server = connect()
   , config = require(process.argv[2])
   , hosts_tag = 'distra'
-  , proxy_options = { hostnameOnly: true, router: {} }
+  , proxy_options = {}
   , port = {
       proxy: parseInt(process.argv[3], 10) || process.env.PORT || 9876,
       static_server: 9999
@@ -18,7 +19,7 @@ var connect = require('connect')
 
 // Log static requests
 static_server
-  .use(connect.logger('dev'));
+  .use(morgan('dev'));
 
 var createStaticServer = function (path) {
   var server = connect();
@@ -35,9 +36,9 @@ Object.keys(config).forEach(function (host) {
   hosts.push({ip: 'fe80::1%lo0', names: [host]});
   if( config[host].slice(0,1) === '/' ) {
     static_server.use(connect.vhost(host, createStaticServer(config[host])));
-    proxy_options.router[host] = host + ':' + port.static_server;
+    proxy_options.target = 'http://' + host + ':' + port.static_server;
   } else {
-    proxy_options.router[host] = config[host];
+    proxy_options.target = 'http://' + config[host];
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   "author": "Tom Ashworth <tom@phuu.net>",
   "license": "MIT",
   "dependencies": {
-    "connect": "~2.7.1",
-    "http-proxy": "~0.8.7",
-    "hostsfile": "~1.0.0",
-    "optimist": "~0.3.5",
+    "connect": "~3.3.4",
     "gzippo": "~0.2.0",
+    "hostsfile": "~1.0.0",
+    "http-proxy": "~1.8.1",
+    "morgan": "^1.5.1",
+    "optimist": "~0.6.1",
     "tabtab": "0.0.2"
   }
 }


### PR DESCRIPTION
I did this to try and fix #8. Unfortunately there still seems to be an issue.

After refreshing several times, Distra now crashes and this error appears:

```
❯ sudo distra 80
Password:

========= restarting =========

proxy listening on 80
static listening on 9999
hostsfile updated

/Users/OliverJAsh/Development/tmp/distra/node_modules/http-proxy/lib/http-proxy/index.js:119
    throw err;
          ^
Error: socket hang up
    at createHangUpError (http.js:1477:15)
    at Socket.socketCloseListener (http.js:1527:23)
    at Socket.emit (events.js:95:17)
    at TCP.close (net.js:466:12)
child exited with code 8
```

Apparently this error message is emitted when the server never sends a response. Any thoughts?
